### PR TITLE
Changed dynamic allocation to handle gcc compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 PyTorch-CTC is an implementation of CTC (Connectionist Temporal Classification) beam search decoding for PyTorch. C++ code borrowed liberally from TensorFlow with some improvements to increase flexibility.
 
 ## Installation
-The library is largely self-contained and requires only PyTorch and CFFI. Building the C++ library requires at least GCC-5. If gcc-5 or later is not your default compiler, you may specify the path via environment variables. KenLM language modeling support is also optionally included, and enabled by default.
+The library is largely self-contained and requires only PyTorch and CFFI. Building the C++ library requires gcc. KenLM language modeling support is also optionally included, and enabled by default.
 
 ```bash
 # get the code
@@ -12,10 +12,7 @@ cd pytorch-ctc
 # install dependencies (PyTorch and CFFI)
 pip install -r requirements.txt
 
-# build the extension and install python package (requires gcc-5 or later)
-# python setup.py install
-CC=/path/to/gcc-5 CXX=/path/to/g++-5 python setup.py install
-
+python setup.py install
 # If you do NOT require kenlm, the `--recursive` flag is not required on git clone
 # and `--exclude-kenlm` should be appended to the `python setup.py install` command
 ```

--- a/pytorch_ctc/src/cpu_binding.cpp
+++ b/pytorch_ctc/src/cpu_binding.cpp
@@ -164,8 +164,8 @@ namespace pytorch {
       for (ctc::CTCDecoder::Output& output : outputs) {
         output.resize(batch_size);
       }
-
-      float score[batch_size][top_paths] = {{0.0}};
+      float score[batch_size][top_paths];
+      memset(score, 0.0, batch_size*top_paths*sizeof(int));
       Eigen::Map<Eigen::MatrixXf> *scores;
 
       // TODO: this is ugly -- can we better leverage generics somehow?


### PR DESCRIPTION
Should allow us to compile on GCC 4.8 or whatever, @ryanleary could you test this? If it works then I'll update the README as well!