### PR TITLE
Changed name of generate trie to generate dict to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ and returns:
 
 ### Utilities
 ```python
-generate_lm_trie(dictionary_path, kenlm_path, output_path, labels, blank_index, space_index)
+generate_lm_dict(dictionary_path, kenlm_path, output_path, labels, blank_index, space_index)
 ```
 
 A vocabulary trie is required for the KenLM Scorer. The trie is created from a lexicon specified as a newline separated text file of words in the vocabulary.

--- a/pytorch_ctc/__init__.py
+++ b/pytorch_ctc/__init__.py
@@ -77,7 +77,8 @@ class KenLMScorer(BaseScorer):
         if ctc._kenlm_enabled() != 1:
             raise ImportError("pytorch-ctc not compiled with KenLM support.")
         self._scorer_type = 1
-        self._scorer = ctc._get_kenlm_scorer(labels, len(labels), space_index, blank_index, lm_path.encode(), trie_path.encode())
+        self._scorer = ctc._get_kenlm_scorer(labels, len(labels), space_index, blank_index, lm_path.encode(),
+                                             trie_path.encode())
 
     def set_lm_weight(self, weight):
         if weight is not None:
@@ -94,17 +95,21 @@ class KenLMScorer(BaseScorer):
 
 class CTCBeamDecoder(BaseCTCBeamDecoder):
     def __init__(self, scorer, labels, top_paths=1, beam_width=10, blank_index=0, space_index=28, merge_repeated=True):
-        super(CTCBeamDecoder, self).__init__(labels, top_paths=top_paths, beam_width=beam_width, blank_index=blank_index, space_index=space_index, merge_repeated=merge_repeated)
+        super(CTCBeamDecoder, self).__init__(labels, top_paths=top_paths, beam_width=beam_width,
+                                             blank_index=blank_index, space_index=space_index,
+                                             merge_repeated=merge_repeated)
         merge_int = 1 if merge_repeated else 0
         self._scorer = scorer
         self._decoder_type = self._scorer.get_scorer_type()
-        self._decoder = ctc._get_ctc_beam_decoder(self._num_classes, top_paths, beam_width, blank_index, merge_int, self._scorer.get_scorer(), self._decoder_type)
+        self._decoder = ctc._get_ctc_beam_decoder(self._num_classes, top_paths, beam_width, blank_index, merge_int,
+                                                  self._scorer.get_scorer(), self._decoder_type)
 
 
-def generate_lm_trie(dictionary_path, kenlm_path, output_path, labels, blank_index=0, space_index=28):
+def generate_lm_dict(dictionary_path, kenlm_path, output_path, labels, blank_index=0, space_index=28):
     if ctc._kenlm_enabled() != 1:
         raise ImportError("pytorch-ctc not compiled with KenLM support.")
-    result = ctc._generate_lm_trie(labels, len(labels), blank_index, space_index, kenlm_path.encode(), dictionary_path.encode(), output_path.encode())
+    result = ctc._generate_lm_dict(labels, len(labels), blank_index, space_index, kenlm_path.encode(),
+                                   dictionary_path.encode(), output_path.encode())
 
     if result != 0:
-        raise ValueError("Error encountered generating trie")
+        raise ValueError("Error encountered generating dictionary")

--- a/pytorch_ctc/src/cpu_binding.cpp
+++ b/pytorch_ctc/src/cpu_binding.cpp
@@ -40,7 +40,7 @@ namespace pytorch {
     return full_score_return.prob;
   }
 
-  int generate_trie(Labels& labels, const char* kenlm_path, const char* vocab_path, const char* trie_path) {
+  int generate_dictionary(Labels& labels, const char* kenlm_path, const char* vocab_path, const char* trie_path) {
     lm::ngram::Config config;
     config.load_method = util::POPULATE_OR_READ;
     Model* model = lm::ngram::LoadVirtual(kenlm_path, config);
@@ -218,11 +218,11 @@ namespace pytorch {
       return 1;
     }
 
-    int generate_lm_trie(const wchar_t* label_str, int size, int blank_index, int space_index,
+    int _generate_lm_dict(const wchar_t* label_str, int size, int blank_index, int space_index,
                          const char* lm_path, const char* dictionary_path, const char* output_path) {
         #ifdef INCLUDE_KENLM
         Labels labels(label_str, size, blank_index, space_index);
-        return generate_trie(labels, lm_path, dictionary_path, output_path);
+        return generate_dictionary(labels, lm_path, dictionary_path, output_path);
         #else
         return -1;
         #endif

--- a/pytorch_ctc/src/cpu_binding.h
+++ b/pytorch_ctc/src/cpu_binding.h
@@ -26,5 +26,5 @@ int ctc_beam_decode(void *decoder, DecodeType type,
 
 
 /* utilities */
-int generate_lm_trie(const wchar_t* labels, int size, int blank_index, int space_index,
+int generate_lm_dict(const wchar_t* labels, int size, int blank_index, int space_index,
                      const char* lm_path, const char* dictionary_path, const char* output_path);


### PR DESCRIPTION
It gets a bit hairy when your model is a .trie, your dictionary is a .trie, this helps to clarify what each is and hide the underlying structure.

Once this is merged/reviewed I'll update deepspeech.pytorch to use the correct function on master!