### PR TITLE
Support time offset information

### DIFF
--- a/pytorch_ctc/__init__.py
+++ b/pytorch_ctc/__init__.py
@@ -47,10 +47,12 @@ class BaseCTCBeamDecoder(object):
         output = torch.IntTensor(self._top_paths, batch_size, max_seq_len)
         scores = torch.FloatTensor(self._top_paths, batch_size)
         out_seq_len = torch.IntTensor(self._top_paths, batch_size)
+        alignments = torch.IntTensor(self._top_paths, batch_size, max_seq_len)
 
-        result = ctc._ctc_beam_decode(self._decoder, self._decoder_type, probs, seq_len, output, scores, out_seq_len)
+        result = ctc._ctc_beam_decode(self._decoder, self._decoder_type, probs, seq_len, output, scores, out_seq_len,
+                                      alignments)
 
-        return output, scores, out_seq_len
+        return output, scores, out_seq_len, alignments
 
 
 class BaseScorer(object):

--- a/pytorch_ctc/src/cpu_binding.h
+++ b/pytorch_ctc/src/cpu_binding.h
@@ -22,7 +22,7 @@ void* get_ctc_beam_decoder(int num_classes, int top_paths, int beam_width, int b
 /* run decoding */
 int ctc_beam_decode(void *decoder, DecodeType type,
                     THFloatTensor *probs, THIntTensor *seq_len, THIntTensor *output,
-                    THFloatTensor *scores, THIntTensor *th_out_len);
+                    THFloatTensor *scores, THIntTensor *th_out_len, THIntTensor *th_alignments);
 
 
 /* utilities */

--- a/tests/test.py
+++ b/tests/test.py
@@ -15,8 +15,8 @@ class CTCDecodeTests(unittest.TestCase):
         decoder_merge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=1, space_index=-1, top_paths=1, beam_width=1, merge_repeated=True)
         decoder_nomerge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=1, space_index=-1, top_paths=1, beam_width=1, merge_repeated=False)
 
-        result_merge, _, result_merge_len = decoder_merge.decode(aa, seq_len)
-        result_nomerge, _, result_nomerge_len = decoder_nomerge.decode(aa, seq_len)
+        result_merge, _, result_merge_len, merge_alignments = decoder_merge.decode(aa, seq_len)
+        result_nomerge, _, result_nomerge_len, nomerge_alignments = decoder_nomerge.decode(aa, seq_len)
         self.assertEqual(result_merge_len[0][0], 1)
         self.assertEqual(result_nomerge_len[0][0], 2)
         self.assertEqual(result_merge.numpy()[0,0,:result_merge_len[0][0]].tolist(), [0])
@@ -31,8 +31,8 @@ class CTCDecodeTests(unittest.TestCase):
         decoder_merge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=1, beam_width=1, merge_repeated=True)
         decoder_nomerge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=1, beam_width=1, merge_repeated=False)
 
-        result_merge, _, result_merge_len = decoder_merge.decode(aa, seq_len)
-        result_nomerge, _, result_nomerge_len = decoder_nomerge.decode(aa, seq_len)
+        result_merge, _, result_merge_len, merge_alignments = decoder_merge.decode(aa, seq_len)
+        result_nomerge, _, result_nomerge_len, nomerge_alignments = decoder_nomerge.decode(aa, seq_len)
 
         self.assertEqual(result_merge_len[0][0], 1)
         self.assertEqual(result_nomerge_len[0][0], 2)
@@ -73,9 +73,8 @@ class CTCDecodeTests(unittest.TestCase):
         scorer = pytorch_ctc.Scorer()
         decoder = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=5, space_index=-1, top_paths=2, beam_width=2, merge_repeated=False)
 
-        decode_result, scores, decode_len = decoder.decode(th_input, th_seq_len)
+        decode_result, scores, decode_len, alignments = decoder.decode(th_input, th_seq_len)
 
-        #self.assertEqual(result_merge.numpy()[0,0,:result_len[0][0]].tolist(), [1])
         self.assertEqual(decode_len[0][0], 2)
         self.assertEqual(decode_len[1][0], 3)
         self.assertEqual(decode_result.numpy()[0,0,:decode_len[0][0]].tolist(), [1, 0])
@@ -116,9 +115,8 @@ class CTCDecodeTests(unittest.TestCase):
         scorer = pytorch_ctc.Scorer()
         decoder = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=2, beam_width=2, merge_repeated=False)
 
-        decode_result, scores, decode_len = decoder.decode(th_input, th_seq_len)
+        decode_result, scores, decode_len, alignments = decoder.decode(th_input, th_seq_len)
 
-        #self.assertEqual(result_merge.numpy()[0,0,:result_len[0][0]].tolist(), [1])
         self.assertEqual(decode_len[0][0], 2)
         self.assertEqual(decode_len[1][0], 3)
         self.assertEqual(decode_result.numpy()[0,0,:decode_len[0][0]].tolist(), [2, 1])


### PR DESCRIPTION
The changes give offset information per character returned relative to the size of the input lattice. This allows you to find out when characters were said!

There is a bug where the first character is always given the timestep value of -1. Any help to try debug this would be great!