### PR TITLE
Remove merge_repeated flag

### DIFF
--- a/pytorch_ctc/__init__.py
+++ b/pytorch_ctc/__init__.py
@@ -18,13 +18,12 @@ _import_symbols(locals())
 
 
 class BaseCTCBeamDecoder(object):
-    def __init__(self, labels, top_paths=1, beam_width=10, blank_index=0, space_index=28, merge_repeated=True):
+    def __init__(self, labels, top_paths=1, beam_width=10, blank_index=0, space_index=28):
         self._labels = labels
         self._top_paths = top_paths
         self._beam_width = beam_width
         self._blank_index = blank_index
         self._space_index = space_index
-        self._merge_repeated = merge_repeated
         self._num_classes = len(labels)
         self._decoder = None
 
@@ -96,14 +95,12 @@ class KenLMScorer(BaseScorer):
 
 
 class CTCBeamDecoder(BaseCTCBeamDecoder):
-    def __init__(self, scorer, labels, top_paths=1, beam_width=10, blank_index=0, space_index=28, merge_repeated=True):
+    def __init__(self, scorer, labels, top_paths=1, beam_width=10, blank_index=0, space_index=28):
         super(CTCBeamDecoder, self).__init__(labels, top_paths=top_paths, beam_width=beam_width,
-                                             blank_index=blank_index, space_index=space_index,
-                                             merge_repeated=merge_repeated)
-        merge_int = 1 if merge_repeated else 0
+                                             blank_index=blank_index, space_index=space_index)
         self._scorer = scorer
         self._decoder_type = self._scorer.get_scorer_type()
-        self._decoder = ctc._get_ctc_beam_decoder(self._num_classes, top_paths, beam_width, blank_index, merge_int,
+        self._decoder = ctc._get_ctc_beam_decoder(self._num_classes, top_paths, beam_width, blank_index,
                                                   self._scorer.get_scorer(), self._decoder_type)
 
 

--- a/pytorch_ctc/src/cpu_binding.cpp
+++ b/pytorch_ctc/src/cpu_binding.cpp
@@ -32,7 +32,7 @@ namespace pytorch {
   float ScoreWord(const Model* model, lm::WordIndex vocab) {
     lm::ngram::State in_state;
     lm::ngram::State out;
-    lm::FullScoreReturn full_score_return; 
+    lm::FullScoreReturn full_score_return;
 
     model->BeginSentenceWrite(&in_state);
     full_score_return = model->BaseFullScore(&in_state, vocab, &out);
@@ -114,13 +114,13 @@ namespace pytorch {
       return static_cast<void *>(beam_scorer);
     }
 
-    void* get_ctc_beam_decoder(int num_classes, int top_paths, int beam_width, int blank_index, int merge_repeated, void *scorer, DecodeType type) {
+    void* get_ctc_beam_decoder(int num_classes, int top_paths, int beam_width, int blank_index, void *scorer, DecodeType type) {
       switch (type) {
         case CTC:
           {
             ctc::CTCBeamSearchDecoder<>::DefaultBeamScorer *beam_scorer = static_cast<ctc::CTCBeamSearchDecoder<>::DefaultBeamScorer *>(scorer);
             ctc::CTCBeamSearchDecoder<> *decoder = new ctc::CTCBeamSearchDecoder<>
-                (num_classes, beam_width, beam_scorer, blank_index, merge_repeated == 1);
+                (num_classes, beam_width, beam_scorer, blank_index);
             return static_cast<void *>(decoder);
           }
         #ifdef INCLUDE_KENLM
@@ -128,7 +128,7 @@ namespace pytorch {
         {
           ctc::KenLMBeamScorer *beam_scorer = static_cast<ctc::KenLMBeamScorer*>(scorer);
           ctc::CTCBeamSearchDecoder<KenLMBeamState> *decoder = new ctc::CTCBeamSearchDecoder<KenLMBeamState>
-              (num_classes, beam_width, beam_scorer, blank_index, merge_repeated == 1);
+              (num_classes, beam_width, beam_scorer, blank_index);
           return static_cast<void *>(decoder);
         }
         #endif

--- a/pytorch_ctc/src/cpu_binding.h
+++ b/pytorch_ctc/src/cpu_binding.h
@@ -16,7 +16,7 @@ void* get_base_scorer();
 
 /* decoders */
 void* get_ctc_beam_decoder(int num_classes, int top_paths, int beam_width, int blank_index,
-                           int merge_repeated, void *scorer, DecodeType type);
+                           void *scorer, DecodeType type);
 
 
 /* run decoding */

--- a/pytorch_ctc/src/ctc_beam_entry.h
+++ b/pytorch_ctc/src/ctc_beam_entry.h
@@ -90,14 +90,12 @@ struct BeamEntry {
     }
     return &children;
   }
-  std::vector<int> LabelSeq(bool merge_repeated) const {
+  std::vector<int> LabelSeq() const {
     std::vector<int> labels;
     int prev_label = -1;
     const BeamEntry* c = this;
     while (c->parent != nullptr) {  // Checking c->parent to skip root leaf.
-      if (!merge_repeated || c->label != prev_label) {
-        labels.push_back(c->label);
-      }
+      labels.push_back(c->label);
       prev_label = c->label;
       c = c->parent;
     }

--- a/pytorch_ctc/src/ctc_beam_search.h
+++ b/pytorch_ctc/src/ctc_beam_search.h
@@ -75,8 +75,8 @@ class CTCBeamSearchDecoder : public CTCDecoder {
   // standard beam search.
   CTCBeamSearchDecoder(int num_classes, int beam_width,
                        BaseBeamScorer<CTCBeamState>* scorer,
-                       int blank_index = 0, bool merge_repeated = false)
-      : CTCDecoder(num_classes, blank_index, merge_repeated),
+                       int blank_index = 0)
+      : CTCDecoder(num_classes, blank_index),
         beam_width_(beam_width),
         leaves_(beam_width),
         // TODO: ADD CHECK_NOTNULL BACK
@@ -117,8 +117,7 @@ class CTCBeamSearchDecoder : public CTCDecoder {
   // Extract the top n paths at current time step
   Status TopPaths(int n, std::vector<std::vector<int>>* paths,
                   std::vector<float>* log_probs,
-                  std::vector<std::vector<int>> *alignments,
-                  bool merge_repeated) const;
+                  std::vector<std::vector<int>> *alignments) const;
 
  private:
   int beam_width_;
@@ -188,8 +187,7 @@ Status CTCBeamSearchDecoder<CTCBeamState, CTCBeamComparer>::Decode(
     }
 
     std::vector<std::vector<int>> beam_alignments;
-    Status status = TopPaths(top_n, &beams, &beam_log_probabilities, &beam_alignments,
-                    merge_repeated_);
+    Status status = TopPaths(top_n, &beams, &beam_log_probabilities, &beam_alignments);
 
     if (!status.ok()) {
       return status;
@@ -365,7 +363,7 @@ void CTCBeamSearchDecoder<CTCBeamState, CTCBeamComparer>::Reset() {
 template <typename CTCBeamState, typename CTCBeamComparer>
 Status CTCBeamSearchDecoder<CTCBeamState, CTCBeamComparer>::TopPaths(
     int n, std::vector<std::vector<int>>* paths, std::vector<float>* log_probs,
-    std::vector<std::vector<int>> *alignments, bool merge_repeated) const {
+    std::vector<std::vector<int>> *alignments) const {
   if (paths == nullptr || log_probs == nullptr) {
     return errors::FailedPrecondition(
       "Internal paths are null"
@@ -393,7 +391,7 @@ Status CTCBeamSearchDecoder<CTCBeamState, CTCBeamComparer>::TopPaths(
 
   for (int i = 0; i < n; ++i) {
     BeamEntry* e((*branches)[i]);
-    paths->push_back(e->LabelSeq(merge_repeated));
+    paths->push_back(e->LabelSeq());
     log_probs->push_back(e->newp.total);
     alignments->push_back(e->TimeStepSeq());
   }

--- a/pytorch_ctc/src/ctc_decoder.h
+++ b/pytorch_ctc/src/ctc_decoder.h
@@ -32,10 +32,9 @@ class CTCDecoder {
   typedef std::vector<std::vector<int>> Output;
   typedef Eigen::Map<Eigen::MatrixXf> ScoreOutput;
 
-  CTCDecoder(int num_classes, int blank_index, bool merge_repeated)
+  CTCDecoder(int num_classes, int blank_index)
       : num_classes_(num_classes),
-        blank_index_(blank_index),
-        merge_repeated_(merge_repeated) {}
+        blank_index_(blank_index) {}
 
   virtual ~CTCDecoder() {}
 
@@ -54,7 +53,6 @@ class CTCDecoder {
  protected:
   int num_classes_;
   int blank_index_;
-  bool merge_repeated_;
 };
 
 // CTCGreedyDecoder is an implementation of the simple best path decoding
@@ -62,7 +60,8 @@ class CTCDecoder {
 class CTCGreedyDecoder : public CTCDecoder {
  public:
   CTCGreedyDecoder(int num_classes, int blank_index, bool merge_repeated)
-      : CTCDecoder(num_classes, blank_index, merge_repeated) {}
+      : CTCDecoder(num_classes, blank_index),
+        merge_repeated_(merge_repeated) {}
 
   Status Decode(const CTCDecoder::SequenceLength& seq_len,
                 std::vector<CTCDecoder::Input>& input,
@@ -101,6 +100,8 @@ class CTCGreedyDecoder : public CTCDecoder {
     }
     return Status::OK();
   }
+ private:
+  bool merge_repeated_;
 };
 
 }  // namespace ctc

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,14 +12,10 @@ class CTCDecodeTests(unittest.TestCase):
 
         labels="A_"
         scorer = pytorch_ctc.Scorer()
-        decoder_merge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=1, space_index=-1, top_paths=1, beam_width=1, merge_repeated=True)
-        decoder_nomerge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=1, space_index=-1, top_paths=1, beam_width=1, merge_repeated=False)
+        decoder_nomerge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=1, space_index=-1, top_paths=1, beam_width=1)
 
-        result_merge, _, result_merge_len, merge_alignments = decoder_merge.decode(aa, seq_len)
         result_nomerge, _, result_nomerge_len, nomerge_alignments = decoder_nomerge.decode(aa, seq_len)
-        self.assertEqual(result_merge_len[0][0], 1)
         self.assertEqual(result_nomerge_len[0][0], 2)
-        self.assertEqual(result_merge.numpy()[0,0,:result_merge_len[0][0]].tolist(), [0])
         self.assertEqual(result_nomerge.numpy()[0,0,:result_nomerge_len[0][0]].tolist(), [0, 0])
 
     def test_simple_decode_different_blank_idx(self):
@@ -28,15 +24,10 @@ class CTCDecodeTests(unittest.TestCase):
 
         labels="_A"
         scorer = pytorch_ctc.Scorer()
-        decoder_merge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=1, beam_width=1, merge_repeated=True)
-        decoder_nomerge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=1, beam_width=1, merge_repeated=False)
+        decoder_nomerge = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=1, beam_width=1)
 
-        result_merge, _, result_merge_len, merge_alignments = decoder_merge.decode(aa, seq_len)
         result_nomerge, _, result_nomerge_len, nomerge_alignments = decoder_nomerge.decode(aa, seq_len)
-
-        self.assertEqual(result_merge_len[0][0], 1)
         self.assertEqual(result_nomerge_len[0][0], 2)
-        self.assertEqual(result_merge.numpy()[0,0,:result_merge_len[0][0]].tolist(), [1])
         self.assertEqual(result_nomerge.numpy()[0,0,:result_nomerge_len[0][0]].tolist(), [1, 1])
 
     def test_ctc_decoder_beam_search(self):
@@ -71,7 +62,7 @@ class CTCDecodeTests(unittest.TestCase):
 
         labels="ABCDE_"
         scorer = pytorch_ctc.Scorer()
-        decoder = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=5, space_index=-1, top_paths=2, beam_width=2, merge_repeated=False)
+        decoder = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=5, space_index=-1, top_paths=2, beam_width=2)
 
         decode_result, scores, decode_len, alignments = decoder.decode(th_input, th_seq_len)
 
@@ -113,7 +104,7 @@ class CTCDecodeTests(unittest.TestCase):
 
         labels="_ABCDE"
         scorer = pytorch_ctc.Scorer()
-        decoder = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=2, beam_width=2, merge_repeated=False)
+        decoder = pytorch_ctc.CTCBeamDecoder(scorer, labels, blank_index=0, space_index=-1, top_paths=2, beam_width=2)
 
         decode_result, scores, decode_len, alignments = decoder.decode(th_input, th_seq_len)
 


### PR DESCRIPTION
See #28. The flag is misleading and produces incorrect results. All results of this function operate as if `merge_repeated` is true.